### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: gkrellm2-cpufreq
 Section: x11
 Priority: optional
 Maintainer: John Paul Adrian Glaubitz <glaubitz@physik.fu-berlin.de>
-Build-Depends: debhelper (>= 12), libcpupower-dev, gkrellm (>= 2.1.4), libgtk2.0-dev
+Build-Depends: debhelper (>= 12), libcpupower-dev, gkrellm, libgtk2.0-dev
 Standards-Version: 4.4.0
 Homepage: http://chw.populus.org/rub/7
 Vcs-Git: git://github.com/glaubitz/gkrellm-cpufreq-debian.git
@@ -10,7 +10,7 @@ Vcs-Browser: https://github.com/glaubitz/gkrellm-cpufreq-debian
 
 Package: gkrellm-cpufreq
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, gkrellm (>= 2.0.0)
+Depends: ${shlibs:Depends}, ${misc:Depends}, gkrellm
 Description: CPU frequency plugin for GKrellM
  gkrellm-cpufreq is an additional plugin for GKrellM that allows one
  to view and set the CPU clock frequency. It also displays the currently


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete). For more information, including instructions on how to disable these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts or close the merge proposal when all changes are applied through other means (e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at https://janitor.debian.net/scrub-obsolete/pkg/gkrellm2-cpufreq/ea3cff05-b53d-4c25-b6fb-3eb8dc8485c5.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/88/aa1e5a012a770d013cd09a7d8483264d546aa3.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/61/42abc77f14752617b12395f91703a3e2694878.debug
### Control files of package gkrellm-cpufreq: lines which differ (wdiff format)
* Depends: libc6 (>= 2.7), libcpupower1 (>= 4.7~rc2-1~exp1), libglib2.0-0 (>= 2.12.0), libgtk2.0-0 (>= 2.8.0), gkrellm [-(>= 2.0.0)-]
### Control files of package gkrellm-cpufreq-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-6142abc77f14752617b12395f91703a3e2694878-] {+88aa1e5a012a770d013cd09a7d8483264d546aa3+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/ea3cff05-b53d-4c25-b6fb-3eb8dc8485c5/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/ea3cff05-b53d-4c25-b6fb-3eb8dc8485c5/diffoscope)).
